### PR TITLE
Improve logging when putting lifecyclepolicy

### DIFF
--- a/pkg/amazon/ecrs/ecr.go
+++ b/pkg/amazon/ecrs/ecr.go
@@ -214,7 +214,7 @@ func (o *Options) EnsureLifecyclePolicy(repoName string) error {
 			return fmt.Errorf("Failed to put lifecycle policy '%s' for the ECR repository %s due to: %s",
 				o.ECRLifecyclePolicy, repoName, err)
 		}
-		log.Logger().Infof("Put ECR repository lifecycle policy: %s", termcolor.ColorInfo(*putLifecyclePolicyOutput))
+		log.Logger().Infof("Put ECR repository lifecycle policy: %s", termcolor.ColorInfo(*(*putLifecyclePolicyOutput).LifecyclePolicyText))
 	}
 	return nil
 }


### PR DESCRIPTION
When adding the functionality to put a lifecyclepolicy I failed in the logging and only the address of the struct is logged. With this fix the actual policy is logged.