### PR TITLE
fix: Use CACHE_SUFFIX env variable

### DIFF
--- a/.lighthouse/jenkins-x/lint.yaml
+++ b/.lighthouse/jenkins-x/lint.yaml
@@ -1,0 +1,27 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  creationTimestamp: null
+  name: lint
+spec:
+  pipelineSpec:
+    tasks:
+    - name: jx-secret-lint
+      resources: {}
+      taskSpec:
+        metadata: {}
+        stepTemplate:
+          image: uses:jenkins-x/jx3-pipeline-catalog/tasks/go/pullrequest.yaml@versionStream
+          name: ""
+          resources: {}
+          workingDir: /workspace/source
+        steps:
+        - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
+          name: ""
+          resources: {}
+        - name: make-lint
+          resources: {}
+  podTemplate: {}
+  serviceAccountName: tekton-bot
+  timeout: 30m0s
+status: {}

--- a/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/.lighthouse/jenkins-x/pullrequest.yaml
@@ -14,16 +14,17 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/go-plugin/pullrequest.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 600Mi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
           name: ""
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            requests:
+              cpu: 400m
+              memory: 600Mi
         - name: build-make-linux
           resources: {}
         - name: build-make-test

--- a/.lighthouse/jenkins-x/triggers.yaml
+++ b/.lighthouse/jenkins-x/triggers.yaml
@@ -9,6 +9,13 @@ spec:
     trigger: "/test"
     rerun_command: "/retest"
     source: "pullrequest.yaml"
+  - name: lint
+    context: "lint"
+    always_run: true
+    optional: false
+    trigger: (?m)^/test( all| lint),?(s+|$)
+    rerun_command: /test lint
+    source: "lint.yaml"
   postsubmits:
   - name: release
     context: "release"

--- a/OWNERS
+++ b/OWNERS
@@ -2,7 +2,9 @@ approvers:
 - rawlingsj
 - jstrachan
 - rajdavies
+- msvticket
 reviewers:
 - rawlingsj
 - jstrachan
 - rajdavies
+- msvticket

--- a/OWNERS
+++ b/OWNERS
@@ -1,10 +1,4 @@
 approvers:
-- rawlingsj
-- jstrachan
-- rajdavies
-- msvticket
+- maintainers
 reviewers:
-- rawlingsj
-- jstrachan
-- rajdavies
-- msvticket
+- maintainers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,6 +1,3 @@
-aliases:
-- rawlingsj
-best-approvers:
-- rawlingsj
-best-reviewers:
-- rawlingsj
+foreignAliases:
+- name: jx-community
+  org: jenkins-x

--- a/cmd/app/main-win.go
+++ b/cmd/app/main-win.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package app

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package app

--- a/cmd/docs/man_docs.go
+++ b/cmd/docs/man_docs.go
@@ -65,7 +65,7 @@ func GenManTreeFromOpts(cmd *cobra.Command, opts GenManTreeOptions) error {
 	if opts.CommandSeparator != "" {
 		separator = opts.CommandSeparator
 	}
-	basename := strings.Replace(cmd.CommandPath(), " ", separator, -1)
+	basename := strings.ReplaceAll(cmd.CommandPath(), " ", separator)
 	filename := filepath.Join(opts.Path, basename+"."+section)
 	f, err := os.Create(filename)
 	if err != nil {
@@ -112,7 +112,7 @@ func GenMan(cmd *cobra.Command, header *GenManHeader, w io.Writer) error {
 
 func fillHeader(header *GenManHeader, name string) error {
 	if header.Title == "" {
-		header.Title = strings.ToUpper(strings.Replace(name, " ", "\\-", -1))
+		header.Title = strings.ToUpper(strings.ReplaceAll(name, " ", "\\-"))
 	}
 	if header.Section == "" {
 		header.Section = "1"
@@ -123,25 +123,25 @@ func fillHeader(header *GenManHeader, name string) error {
 	return nil
 }
 
-func manPreamble(buf *bytes.Buffer, header *GenManHeader, cmd *cobra.Command, dashedName string) {
+func manPreamble(buf io.StringWriter, header *GenManHeader, cmd *cobra.Command, dashedName string) {
 	description := cmd.Long
 	if len(description) == 0 {
 		description = cmd.Short
 	}
 
-	buf.WriteString(fmt.Sprintf(`%% %s(%s)
+	_, _ = buf.WriteString(fmt.Sprintf(`%% %s(%s)
 %% %s
 %% %s
 # NAME
 `, header.Title, header.Section, header.Source, header.Manual))
-	buf.WriteString(fmt.Sprintf("%s \\- %s\n\n", dashedName, cmd.Short))
-	buf.WriteString("# SYNOPSIS\n")
-	buf.WriteString(fmt.Sprintf("**%s**\n\n", cmd.UseLine()))
-	buf.WriteString("# DESCRIPTION\n")
-	buf.WriteString(description + "\n\n")
+	_, _ = buf.WriteString(fmt.Sprintf("%s \\- %s\n\n", dashedName, cmd.Short))
+	_, _ = buf.WriteString("# SYNOPSIS\n")
+	_, _ = buf.WriteString(fmt.Sprintf("**%s**\n\n", cmd.UseLine()))
+	_, _ = buf.WriteString("# DESCRIPTION\n")
+	_, _ = buf.WriteString(description + "\n\n")
 }
 
-func manPrintFlags(buf *bytes.Buffer, flags *pflag.FlagSet) {
+func manPrintFlags(buf io.StringWriter, flags *pflag.FlagSet) {
 	flags.VisitAll(func(flag *pflag.Flag) {
 		if len(flag.Deprecated) > 0 || flag.Hidden {
 			return
@@ -165,22 +165,22 @@ func manPrintFlags(buf *bytes.Buffer, flags *pflag.FlagSet) {
 			format += "]"
 		}
 		format += "\n\t%s\n\n"
-		buf.WriteString(fmt.Sprintf(format, flag.DefValue, flag.Usage))
+		_, _ = buf.WriteString(fmt.Sprintf(format, flag.DefValue, flag.Usage))
 	})
 }
 
-func manPrintOptions(buf *bytes.Buffer, command *cobra.Command) {
+func manPrintOptions(buf io.StringWriter, command *cobra.Command) {
 	flags := command.NonInheritedFlags()
 	if flags.HasAvailableFlags() {
-		buf.WriteString("# OPTIONS\n")
+		_, _ = buf.WriteString("# OPTIONS\n")
 		manPrintFlags(buf, flags)
-		buf.WriteString("\n")
+		_, _ = buf.WriteString("\n")
 	}
 	flags = command.InheritedFlags()
 	if flags.HasAvailableFlags() {
-		buf.WriteString("# OPTIONS INHERITED FROM PARENT COMMANDS\n")
+		_, _ = buf.WriteString("# OPTIONS INHERITED FROM PARENT COMMANDS\n")
 		manPrintFlags(buf, flags)
-		buf.WriteString("\n")
+		_, _ = buf.WriteString("\n")
 	}
 }
 
@@ -189,7 +189,7 @@ func genMan(cmd *cobra.Command, header *GenManHeader) []byte {
 	cmd.InitDefaultHelpFlag()
 
 	// something like `rootcmd-subcmd1-subcmd2`
-	dashCommandName := strings.Replace(cmd.CommandPath(), " ", "-", -1)
+	dashCommandName := strings.ReplaceAll(cmd.CommandPath(), " ", "-")
 
 	buf := new(bytes.Buffer)
 
@@ -204,7 +204,7 @@ func genMan(cmd *cobra.Command, header *GenManHeader) []byte {
 		seealsos := make([]string, 0)
 		if cmd.HasParent() {
 			parentPath := cmd.Parent().CommandPath()
-			dashParentPath := strings.Replace(parentPath, " ", "-", -1)
+			dashParentPath := strings.ReplaceAll(parentPath, " ", "-")
 			seealso := fmt.Sprintf("**%s(%s)**", dashParentPath, header.Section)
 			seealsos = append(seealsos, seealso)
 			cmd.VisitParents(func(c *cobra.Command) {

--- a/cmd/docs/md_docs.go
+++ b/cmd/docs/md_docs.go
@@ -26,7 +26,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func printOptions(buf *bytes.Buffer, cmd *cobra.Command, name string) error {
+func printOptions(buf *bytes.Buffer, cmd *cobra.Command) error {
 	flags := cmd.NonInheritedFlags()
 	flags.SetOutput(buf)
 	if flags.HasAvailableFlags() {
@@ -80,7 +80,7 @@ func GenMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string)
 		buf.WriteString(fmt.Sprintf("%s\n\n", cmd.Example))
 	}
 
-	if err := printOptions(buf, cmd, name); err != nil {
+	if err := printOptions(buf, cmd); err != nil {
 		return err
 	}
 	if hasSeeAlso(cmd) {
@@ -89,7 +89,7 @@ func GenMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string)
 			parent := cmd.Parent()
 			pname := parent.CommandPath()
 			link := pname + ".md"
-			link = strings.Replace(link, " ", "_", -1)
+			link = strings.ReplaceAll(link, " ", "_")
 			buf.WriteString(fmt.Sprintf("* [%s](%s)\t - %s\n", pname, linkHandler(link), parent.Short))
 			cmd.VisitParents(func(c *cobra.Command) {
 				if c.DisableAutoGenTag {
@@ -107,7 +107,7 @@ func GenMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string)
 			}
 			cname := name + " " + child.Name()
 			link := cname + ".md"
-			link = strings.Replace(link, " ", "_", -1)
+			link = strings.ReplaceAll(link, " ", "_")
 			buf.WriteString(fmt.Sprintf("* [%s](%s)\t - %s\n", cname, linkHandler(link), child.Short))
 		}
 		buf.WriteString("\n")
@@ -143,7 +143,7 @@ func GenMarkdownTreeCustom(cmd *cobra.Command, dir string, filePrepender, linkHa
 		}
 	}
 
-	basename := strings.Replace(cmd.CommandPath(), " ", "_", -1) + ".md"
+	basename := strings.ReplaceAll(cmd.CommandPath(), " ", "_") + ".md"
 	filename := filepath.Join(dir, basename)
 	f, err := os.Create(filename)
 	if err != nil {

--- a/pkg/amazon/ecrs/ecr.go
+++ b/pkg/amazon/ecrs/ecr.go
@@ -230,7 +230,7 @@ func (o *Options) EnsureLifecyclePolicy(repoName string) error {
 			return fmt.Errorf("Failed to put lifecycle policy '%s' for the ECR repository %s due to: %s",
 				o.ECRLifecyclePolicy, repoName, err)
 		}
-		log.Logger().Infof("Put ECR repository lifecycle policy: %s", termcolor.ColorInfo(*(*putLifecyclePolicyOutput).LifecyclePolicyText))
+		log.Logger().Infof("Put ECR repository lifecycle policy: %s", termcolor.ColorInfo(*putLifecyclePolicyOutput.LifecyclePolicyText))
 	}
 	return o.EnsureRepositoryPolicy(repoName)
 }
@@ -278,6 +278,6 @@ func (o *Options) EnsureRepositoryPolicy(repoName string) error {
 		return fmt.Errorf("Failed to set repository policy '%s' for the ECR repository %s due to: %s",
 			o.ECRRepositoryPolicy, repoName, err)
 	}
-	log.Logger().Infof("Put ECR repository repository policy: %s", termcolor.ColorInfo(*(*setRegistryPolicyOutput).PolicyText))
+	log.Logger().Infof("Put ECR repository repository policy: %s", termcolor.ColorInfo(*setRegistryPolicyOutput.PolicyText))
 	return nil
 }

--- a/pkg/amazon/ecrs/ecr.go
+++ b/pkg/amazon/ecrs/ecr.go
@@ -69,6 +69,7 @@ type Options struct {
 	CreateECRLifeCyclePolicy  bool   `env:"CREATE_ECR_LIFECYCLE_POLICY,default=true"`
 	CreateECRRepositoryPolicy bool   `env:"CREATE_ECR_REPOSITORY_POLICY,default=false"`
 	ECRClient                 ECRClient
+	CacheSuffix               string `env:"CACHE_SUFFIX"` // CacheSuffix is declared here to get handling of env to work
 }
 
 func (o *Options) AddFlags(cmd *cobra.Command) {
@@ -236,7 +237,7 @@ func (o *Options) EnsureLifecyclePolicy(repoName string) error {
 
 func (o *Options) EnsureRepositoryPolicy(repoName string) error {
 	if !o.CreateECRRepositoryPolicy {
-		return nil 
+		return nil
 	}
 	client := o.ECRClient
 	ctx := o.GetContext()

--- a/pkg/amazon/helpers.go
+++ b/pkg/amazon/helpers.go
@@ -21,7 +21,6 @@ type Options struct {
 
 func (o *Options) GetConfig() (*aws.Config, error) {
 	if o.Config != nil {
-		log.Logger().Infof("aready has AWS config")
 		return o.Config, nil
 	}
 	if o.Context == nil {

--- a/pkg/cmd/create/create.go
+++ b/pkg/cmd/create/create.go
@@ -42,7 +42,6 @@ type Options struct {
 	options.BaseOptions
 	ecrs.Options
 
-	CacheSuffix   string `env:"CACHE_SUFFIX"`
 	ECRSuffix     string
 	Namespace     string
 	Owner         string

--- a/pkg/cmd/create/create_test.go
+++ b/pkg/cmd/create/create_test.go
@@ -10,11 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var (
-	// generateTestOutput enable to regenerate the expected output
-	generateTestOutput = false
-)
-
 func TestCreateForNonEKS(t *testing.T) {
 	_, o := create.NewCmdCreate()
 


### PR DESCRIPTION
This fixes that CACHE_SUFFIX wasn't read. The reason is that `envconfig.Process` wasn't called on the struct containing cacheSuffix.

The obvious solution to call `envconfig.Process(o.GetContext(), o)` in create.go failed with `WARNING: failed to default env vars: Requirements: unexpected end of JSON input`. Thus this slightly ugly fix.

I also had to do various fixes to get the code throught the linter. And while at it I added myself to the OWNERS file.